### PR TITLE
Use Domain ID when fetching the device list from netshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ OPTIONS:
             The Netshot token [env: NETSHOT_TOKEN]
 
         --netshot-url <netshot-url>
-            The Netshot API URL [env: NETSHOT_URL=]```
+            The Netshot API URL [env: NETSHOT_URL=]
+```
 
 The query-string format need to be like this (url query string without the `?`):
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn main() -> Result<(), Error> {
     netshot_client.ping()?;
 
     log::info!("Getting devices list from Netshot");
-    let netshot_devices = netshot_client.get_devices()?;
+    let netshot_devices = netshot_client.get_devices(opt.netshot_domain_id)?;
 
     let netshot_disabled_devices: Vec<&netshot::Device> = netshot_devices
         .iter()

--- a/src/rest/netbox.rs
+++ b/src/rest/netbox.rs
@@ -35,7 +35,7 @@ pub struct Device {
     pub primary_ip4: Option<PrimaryIP>,
 }
 
-/// Represent the API response from /api/devim/devices call
+/// Represent the API response from /api/dcim/devices call
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NetboxDCIMDeviceList {
     count: u32,

--- a/src/rest/netshot.rs
+++ b/src/rest/netshot.rs
@@ -121,8 +121,10 @@ impl NetshotClient {
     }
 
     /// Get devices registered in Netshot
-    pub fn get_devices(&self) -> Result<Vec<Device>, Error> {
-        let url = format!("{}{}", self.url, PATH_DEVICES);
+    pub fn get_devices(&self,
+                       domain_id: u32,
+    ) -> Result<Vec<Device>, Error> {
+        let url = format!("{}{}?group={}", self.url, PATH_DEVICES, domain_id);
         let devices: Vec<Device> = self.client.get(url).send()?.json()?;
 
         log::debug!("Got {} devices from Netshot", devices.len());


### PR DESCRIPTION
When syncing between netbox and netshot, we already need to pass the netshot_domain_id. Newly added devices are added in that domain.

However, when fetching the list in netshot, so we know what devices to disable, we don't use that domain_id, so we will disable all devices instead of just the ones we are trying to sync.

I have a usecase with two groups of devices in netbox, that have a different device role (customers, backbone). Each role goes into it's own domain in netshot. The current code will disable all devices from the customer domain, when I sync the backbone domain and visa versa.

Example commands to sync both groups:
```
$ netbox2netshot --netbox-url http://x.x.x.x --netbox-token xxx --netbox-devices-filter "status=active,role=cpe" --netshot-url https://y.y.y.y --netshot-token yyy --netshot-domain-id 1
$ netbox2netshot --netbox-url http://x.x.x.x --netbox-token xxx --netbox-devices-filter "status=active,role=backbone" --netshot-url https://y.y.y.y --netshot-token yyy --netshot-domain-id 2
```

This MR fixes this, by fetching only the devices that we are actually trying to sync.

As a small bonus, I fixed two typo's.