### PR TITLE
Cargo fix lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "netbox2netshot"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "ctor",


### PR DESCRIPTION
There was a small mistake with the version bump, the version of netbox2netshot also needs to be bumped in the `cargo.lock` file