### PR TITLE
Migrate from StructOpt to Clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,18 +189,49 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -390,12 +471,9 @@ checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -639,6 +717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,13 +840,13 @@ name = "netbox2netshot"
 version = "0.1.13"
 dependencies = [
  "anyhow",
+ "clap",
  "ctor",
  "flexi_logger",
  "log",
  "mockito",
  "reqwest",
  "serde",
- "structopt",
 ]
 
 [[package]]
@@ -876,30 +960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -1174,33 +1234,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1273,15 +1309,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1423,18 +1450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "url"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,22 +1473,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 serde = { version = "1.0.125", features = ["derive"]}
-structopt = "0.3"
+clap = { version = "4.0", features = ["derive", "env"] }
 log = "0.4"
 flexi_logger = "0.19"
 reqwest = { version = "0.11", features = ["json", "native-tls", "blocking"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,64 +2,64 @@ use std::collections::HashMap;
 
 use anyhow::{Error, Result};
 use flexi_logger::{Duplicate, FileSpec, Logger};
-use structopt::StructOpt;
+use clap::Parser;
 
 use rest::{netbox, netshot};
 
 mod common;
 mod rest;
 
-#[derive(Debug, StructOpt, Clone)]
-#[structopt(
+#[derive(Debug, Parser, Clone)]
+#[command(
     name = "netbox2netshot",
     about = "Synchronization tool between netbox and netshot"
 )]
 struct Opt {
-    #[structopt(short, long, help = "Enable debug/verbose mode")]
+    #[arg(short, long, help = "Enable debug/verbose mode")]
     debug: bool,
 
-    #[structopt(long, help = "The directory to log to", default_value = "logs", env)]
+    #[arg(long, help = "The directory to log to", default_value = "logs", env)]
     log_directory: String,
 
-    #[structopt(long, help = "The Netshot API URL", env)]
+    #[arg(long, help = "The Netshot API URL", env)]
     netshot_url: String,
 
-    #[structopt(
+    #[arg(
         long,
         help = "The TLS certificate to use to authenticate to Netshot (PKCS12 format)",
         env
     )]
     netshot_tls_client_certificate: Option<String>,
 
-    #[structopt(long, help = "The optional password for the netshot PKCS12 file", env)]
+    #[arg(long, help = "The optional password for the netshot PKCS12 file", env)]
     netshot_tls_client_certificate_password: Option<String>,
 
-    #[structopt(long, help = "The Netshot token", env, hide_env_values = true)]
+    #[arg(long, help = "The Netshot token", env, hide_env_values = true)]
     netshot_token: String,
 
-    #[structopt(long, help = "The domain ID to use when importing a new device", env)]
+    #[arg(long, help = "The domain ID to use when importing a new device", env)]
     netshot_domain_id: u32,
 
-    #[structopt(long, help = "HTTP(s) proxy to use to connect to Netshot", env)]
+    #[arg(long, help = "HTTP(s) proxy to use to connect to Netshot", env)]
     netshot_proxy: Option<String>,
 
-    #[structopt(long, help = "The Netbox API URL", env)]
+    #[arg(long, help = "The Netbox API URL", env)]
     netbox_url: String,
 
-    #[structopt(
+    #[arg(
         long,
         help = "The TLS certificate to use to authenticate to Netbox (PKCS12 format)",
         env
     )]
     netbox_tls_client_certificate: Option<String>,
 
-    #[structopt(long, help = "The optional password for the netbox PKCS12 file", env)]
+    #[arg(long, help = "The optional password for the netbox PKCS12 file", env)]
     netbox_tls_client_certificate_password: Option<String>,
 
-    #[structopt(long, help = "The Netbox token", env, hide_env_values = true)]
+    #[arg(long, help = "The Netbox token", env, hide_env_values = true)]
     netbox_token: Option<String>,
 
-    #[structopt(
+    #[arg(
         long,
         default_value = "",
         help = "The querystring to use to select the devices from netbox",
@@ -67,23 +67,23 @@ struct Opt {
     )]
     netbox_devices_filter: String,
 
-    #[structopt(
+    #[arg(
         long,
         help = "The querystring to use to select the VM from netbox",
         env
     )]
     netbox_vms_filter: Option<String>,
 
-    #[structopt(long, help = "HTTP(s) proxy to use to connect to Netbox", env)]
+    #[arg(long, help = "HTTP(s) proxy to use to connect to Netbox", env)]
     netbox_proxy: Option<String>,
 
-    #[structopt(short, long, help = "Check mode, will not push any change to Netshot")]
+    #[arg(short, long, help = "Check mode, will not push any change to Netshot")]
     check: bool,
 }
 
 /// Main application entrypoint
 fn main() -> Result<(), Error> {
-    let opt: Opt = Opt::from_args();
+    let opt: Opt = Opt::parse();
     let mut logging_level = "info";
     let mut duplicate_level = Duplicate::Info;
     if opt.debug {


### PR DESCRIPTION
It seems StructOpt doesn't support from_args anymore, and the whole functionality is merged into clap. This PR migrates to Clap.

Fixes #20 