### PR TITLE
Netshot update

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ fn main() -> Result<(), Error> {
     log::debug!("Building netshot devices simplified inventory");
     let netshot_simplified_inventory: HashMap<&String, &String> = netshot_devices
         .iter()
-        .map(|dev| (&dev.management_address.ip, &dev.name))
+        .map(|dev| (&dev.management_address, &dev.name))
         .collect();
 
     log::info!("Getting devices list from Netbox");
@@ -192,14 +192,14 @@ fn main() -> Result<(), Error> {
 
     let mut devices_to_enable: Vec<String> = Vec::new();
     for device in &netshot_disabled_devices {
-        match netbox_simplified_devices.get(device.management_address.ip.as_str()) {
+        match netbox_simplified_devices.get(&device.management_address) {
             Some(_x) => {
                 log::debug!(
                     "{}({}) to be enabled (present on Netbox)",
                     device.name,
-                    device.management_address.ip
+                    device.management_address
                 );
-                devices_to_enable.push(device.management_address.ip.clone());
+                devices_to_enable.push(device.management_address.clone());
             }
             None => {}
         }

--- a/src/rest/netshot.rs
+++ b/src/rest/netshot.rs
@@ -18,20 +18,11 @@ pub struct NetshotClient {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ManagementAddress {
-    #[serde(rename = "prefixLength")]
-    pub prefix_length: u8,
-    #[serde(rename = "addressUsage")]
-    pub address_usage: String,
-    pub ip: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
 pub struct Device {
     pub id: u32,
     pub name: String,
     #[serde(rename = "mgmtAddress")]
-    pub management_address: ManagementAddress,
+    pub management_address: String,
     pub status: String,
 }
 
@@ -301,7 +292,7 @@ mod tests {
 
         assert_eq!(device.name, "test-device");
         assert_eq!(device.id, 1 as u32);
-        assert_eq!(device.management_address.ip, "1.2.3.4");
+        assert_eq!(device.management_address, "1.2.3.4");
     }
 
     #[test]

--- a/tests/data/netshot/search.json
+++ b/tests/data/netshot/search.json
@@ -5,22 +5,14 @@
       "id": 2318,
       "name": "test-device.dc",
       "family": "Cisco Catalyst 2900",
-      "mgmtAddress": {
-        "prefixLength": 0,
-        "addressUsage": "PRIMARY",
-        "ip": "1.2.3.4"
-      },
+      "mgmtAddress": "1.2.3.4",
       "status": "INPRODUCTION"
     },
     {
       "id": 2318,
       "name": "test-device.dc",
       "family": "Cisco Catalyst 2900",
-      "mgmtAddress": {
-        "prefixLength": 0,
-        "addressUsage": "PRIMARY",
-        "ip": "1.2.3.4"
-      },
+      "mgmtAddress": "1.2.3.4",
       "status": "INPRODUCTION"
     }
   ]

--- a/tests/data/netshot/single_good_device.json
+++ b/tests/data/netshot/single_good_device.json
@@ -3,11 +3,7 @@
     "id": 1,
     "name": "test-device",
     "family": "Nexus 9000 C93108TC-EX",
-    "mgmtAddress": {
-      "prefixLength": 0,
-      "addressUsage": "PRIMARY",
-      "ip": "1.2.3.4"
-    },
+    "mgmtAddress": "1.2.3.4",
     "status": "INPRODUCTION"
   }
 ]


### PR DESCRIPTION
Netshot has been updated and the mgmtAddress is a string now instead of a ManagementAddress.

This PR fixes this issue.

Fixes #19 